### PR TITLE
Module interface rework

### DIFF
--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -261,7 +261,6 @@ architecture Behavioral of one_wire_wrapper is
   signal copy_status, ta1, es : std_logic_vector(7 downto 0);
   constant ta2                : std_logic_vector(7 downto 0) := x"00";
   signal scratchpad_contents  : vector_array (0 to ((scratchpad_size/8) - 1));
-  signal eeprom_contents      : vector_array (0 to ((eeprom_size/8) - 1));
   
   signal index, wait_count    : integer;
   signal data_out             : std_logic_vector(7 downto 0);
@@ -954,7 +953,10 @@ if (rising_edge(clk_1mhz)) then
         else 
             ta1  <= std_logic_vector(to_unsigned(scratchpad_write_count*8,8));
             for i in 0 to 7 loop
-                scratchpad_contents(i) <= eeprom_contents((scratchpad_write_count*8)+i);
+--                scratchpad_contents(i) <= eeprom_contents((scratchpad_write_count*8)+i);
+                  scratchpad_contents(i) <= MEMORY_IN((8 * (8*scratchpad_write_count + 1+i)) - 1 
+                                                       downto 
+                                                       8 * (8*scratchpad_write_count+i));
             end loop;
             scratchpad_write_count <= scratchpad_write_count + 1;
             ow_state <= write_page_to_eeprom;
@@ -976,9 +978,9 @@ if (rising_edge(clk_1mhz)) then
         if (WR = '1') then
           RDY <= '0';
           ta1 <= x"00";
-          for i in 0 to eeprom_contents'length - 1 loop
-            eeprom_contents(i) <= MEMORY_IN((8 * (i + 1)) - 1 downto 8 * i);
-          end loop;
+--          for i in 0 to eeprom_contents'length - 1 loop
+--            eeprom_contents(i) <= MEMORY_IN((8 * (i + 1)) - 1 downto 8 * i);
+--          end loop;
           scratchpad_write_count <= 0;
           ow_state <= write_eeprom;
           

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -5,13 +5,13 @@
 -- Copyright 2020 Orthogonal Systems LLC, Collin Anderson, Ian Wisher
 -- SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 --
--- Licensed under the Solderpad Hardware License v 2.1 (the “License�?); you may not use this file except in compliance
+-- Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
 -- with the License, or, at your option, the Apache License version 2.0. You may obtain a copy of the License at
 --
 -- https://solderpad.org/licenses/SHL-2.1/
 --
 -- Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
--- an “AS IS�? BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 -----------------------------------------------------------------------------------------------------------------------
 

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -471,6 +471,7 @@ begin
     else
       after_next_ow_state <= ow_state;
       ow_state            <= ow_rx;
+      setup_count <= 6;
     end if;
   end if;
   sequence_num := sequence_num + 1;
@@ -487,6 +488,7 @@ begin
       index               <= index + 1;
       after_next_ow_state <= ow_state;
       ow_state            <= ow_rx;
+      setup_count <= 6;
     end if;
     if index > 0 then
       rx(index - 1) <= read_buffer;

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -5,13 +5,13 @@
 -- Copyright 2020 Orthogonal Systems LLC, Collin Anderson, Ian Wisher
 -- SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 --
--- Licensed under the Solderpad Hardware License v 2.1 (the “License�?); you may not use this file except in compliance
+-- Licensed under the Solderpad Hardware License v 2.1 (the “License�?); you may not use this file except in compliance
 -- with the License, or, at your option, the Apache License version 2.0. You may obtain a copy of the License at
 --
 -- https://solderpad.org/licenses/SHL-2.1/
 --
 -- Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
--- an “AS IS�? BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- an “AS IS�? BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 -----------------------------------------------------------------------------------------------------------------------
 
@@ -221,6 +221,7 @@ architecture Behavioral of one_wire_wrapper is
     read_serial,
     waiting_for_send,
     waiting_for_response,
+    load_id,
     validate_id,
     write_to_scratchpad,
     read_from_scratchpad,
@@ -818,7 +819,7 @@ if (rising_edge(clk_1mhz)) then
           read_done   <= true;
         end if;
 
-      when validate_id =>
+      when load_id =>
         id_vec(7 downto 0)   <= id_buffer(0);
         id_vec(15 downto 8)  <= id_buffer(1);
         id_vec(23 downto 16) <= id_buffer(2);
@@ -828,6 +829,11 @@ if (rising_edge(clk_1mhz)) then
         id_vec(55 downto 48) <= id_buffer(6);
         id_vec(63 downto 56) <= id_buffer(7);
         serial_crc           <= id_buffer(7);
+        
+        ow(proceed_to => validate_id);
+        
+        
+     when validate_id =>
         if crc8_56w(id_vec(55 downto 0)) = serial_crc then
             serial_id_valid <= '1';
             serial_id       <= id_vec;
@@ -902,7 +908,7 @@ if (rising_edge(clk_1mhz)) then
         ow(bus_reset);
         ow(tx         => READ_SERIAL_ID);
         ow(rx         => id_buffer);
-        ow(proceed_to => validate_id);
+        ow(proceed_to => load_id);
 
       when idle =>
         if (CLR = '1') then

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -269,7 +269,6 @@ architecture Behavioral of one_wire_wrapper is
   constant scratchpad_count     : natural :=  eeprom_size/scratchpad_size;
   signal scratchpad_write_count : natural :=  0;
 
-
   signal int_register   : std_logic_vector(7 downto 0);
   signal setup_count    : integer := 6;
   signal scratchpad_crc : vector_array (0 to 1);
@@ -611,6 +610,7 @@ if (rising_edge(clk_1mhz)) then
         ADDRESS     <= b"000";
         --setup_count <= 6;
         ow_state    <= enabling_ow_clock;
+
         
       when enabling_ow_clock =>
         if (setup_count = 6) then
@@ -642,6 +642,7 @@ if (rising_edge(clk_1mhz)) then
           setup_count <= 6;
           ow_state    <= read_serial;
         end if;
+
         
       when wait4prog =>
         if (wait_count = 12500) then
@@ -651,6 +652,7 @@ if (rising_edge(clk_1mhz)) then
           ow_state   <= wait4prog;
           wait_count <= wait_count + 1;
         end if;
+
 
       when generating_ow_reset =>
         if (setup_count = 6) then
@@ -683,6 +685,7 @@ if (rising_edge(clk_1mhz)) then
           ow_state    <= waiting_for_reset;
         end if;
 
+
       when waiting_for_reset =>
         if (int_register(0) = '0') then
           ow_state      <= updating_int_register;
@@ -690,6 +693,7 @@ if (rising_edge(clk_1mhz)) then
         else
           ow_state <= after_next_ow_state;
         end if;
+
 
       when updating_int_register =>
         if (setup_count = 6) then
@@ -720,6 +724,7 @@ if (rising_edge(clk_1mhz)) then
           setup_count <= 6;
           ow_state    <= next_ow_state;
         end if;
+
 
       when ow_tx =>
         if (setup_count = 6) then
@@ -754,6 +759,7 @@ if (rising_edge(clk_1mhz)) then
           write_done    <= True;
         end if;
 
+
       when waiting_for_send =>
         if (int_register(3) = '1') then
           ow_state <= after_next_ow_state;
@@ -762,6 +768,7 @@ if (rising_edge(clk_1mhz)) then
           ow_state      <= updating_int_register;
           next_ow_state <= waiting_for_send;
         end if;
+
 
       when ow_rx =>
         if (setup_count = 6) then
@@ -795,6 +802,7 @@ if (rising_edge(clk_1mhz)) then
           next_ow_state <= waiting_for_response;
         end if;
 
+
       when waiting_for_response =>
         if (int_register(4) = '1' and int_register(3) = '1') then
           ow_state <= ow_rx_byte;
@@ -802,6 +810,7 @@ if (rising_edge(clk_1mhz)) then
           ow_state      <= updating_int_register;
           next_ow_state <= waiting_for_response;
         end if;
+
 
       when ow_rx_byte =>
         if (setup_count = 6) then
@@ -833,6 +842,7 @@ if (rising_edge(clk_1mhz)) then
           ow_state    <= after_next_ow_state;
           read_done   <= true;
         end if;
+
 
       when load_id =>
         id_vec(7 downto 0)   <= id_buffer(0);
@@ -953,7 +963,6 @@ if (rising_edge(clk_1mhz)) then
         else 
             ta1  <= std_logic_vector(to_unsigned(scratchpad_write_count*8,8));
             for i in 0 to 7 loop
---                scratchpad_contents(i) <= eeprom_contents((scratchpad_write_count*8)+i);
                   scratchpad_contents(i) <= MEMORY_IN((8 * (8*scratchpad_write_count + 1+i)) - 1 
                                                        downto 
                                                        8 * (8*scratchpad_write_count+i));
@@ -961,9 +970,7 @@ if (rising_edge(clk_1mhz)) then
             scratchpad_write_count <= scratchpad_write_count + 1;
             ow_state <= write_page_to_eeprom;
         end if;     
-            
-   
-                                        
+                               
       when read_serial =>
         ow(bus_reset);
         ow(tx         => READ_SERIAL_ID);
@@ -972,15 +979,15 @@ if (rising_edge(clk_1mhz)) then
 
       when idle =>
         if (CLR = '1') then
-          ERR <= '0';
+          ERR             <= '0';
+          serial_id       <= (others => '0');
+          serial_id_valid <= '0';
+          MEMORY_OUT      <= (others => '0');   
         end if;
 
         if (WR = '1') then
           RDY <= '0';
           ta1 <= x"00";
---          for i in 0 to eeprom_contents'length - 1 loop
---            eeprom_contents(i) <= MEMORY_IN((8 * (i + 1)) - 1 downto 8 * i);
---          end loop;
           scratchpad_write_count <= 0;
           ow_state <= write_eeprom;
           

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -27,7 +27,6 @@ entity one_wire_wrapper is
     eeprom_size     : integer := 1024;
     read_chunk      : integer := 64
   );
-
   port (
     clk_1mhz        : in     std_logic;
     reset           : in     std_logic;
@@ -49,12 +48,9 @@ architecture Behavioral of one_wire_wrapper is
   component one_wire_io
     port (
       CLK        : in std_logic;
-      DDIR       : in std_logic;
-      DOUT       : in std_logic_vector(7 downto 0);
-      DQ_CONTROL : in std_logic;
       MR         : in std_logic;
+      DQ_CONTROL : in std_logic;
       DQ_IN      : out   std_logic;
-      DATA       : inout std_logic_vector(7 downto 0);
       DQ         : inout std_logic
     );
   end component;
@@ -302,12 +298,9 @@ begin
   xone_wire_io : one_wire_io
   port map(
     CLK        => clk_1mhz,
-    DDIR       => DDIR,
-    DOUT       => DOUT,
-    DQ_CONTROL => DQ_CONTROL,
     MR         => MR,
     DQ_IN      => DQ_IN,
-    DATA       => DATA,
+    DQ_CONTROL => DQ_CONTROL,
     DQ         => one_wire
   );
 

--- a/eeprom_reader.vhd
+++ b/eeprom_reader.vhd
@@ -416,8 +416,8 @@ begin
     sequence_num := sequence_num + 1;
   end procedure;
 
-  procedure ow(constant tx : in vector_array;
-  constant addr            : in std_logic_vector(2 downto 0) := b"001") is
+procedure ow(constant tx : in vector_array;
+constant addr            : in std_logic_vector(2 downto 0) := b"001") is
 begin
   if cur_step = sequence_num then
     if write_done = true then
@@ -568,6 +568,7 @@ end function;
 
 begin
 if (rising_edge(clk_1mhz)) then
+  sequence_num := 0;      
   if (reset = '1') then
     ADDRESS         <= b"000";
     ADS_bar         <= '0';
@@ -597,7 +598,7 @@ if (rising_edge(clk_1mhz)) then
       when setup =>
         MR          <= '0';
         ADDRESS     <= b"000";
-        setup_count <= 6;
+        --setup_count <= 6;
         ow_state    <= enabling_ow_clock;
         
       when enabling_ow_clock =>

--- a/one_wire_io.vhd
+++ b/one_wire_io.vhd
@@ -27,22 +27,15 @@ use IEEE.std_logic_1164.all;
 entity one_wire_io is
   port(
     CLK                        :  IN std_logic;
-    DDIR                       :  IN std_logic;
-    DOUT                       :  IN std_logic_vector(7 DOWNTO 0);
     DQ_CONTROL                 :  IN std_logic;
     MR                         :  IN std_logic;
-    --DIN                        :  OUT std_logic_vector(7 DOWNTO 0);
     DQ_IN                      :  OUT std_logic;
-    DATA                       :  INOUT std_logic_vector(7 DOWNTO 0);
     DQ                         :  INOUT std_logic);
 end one_wire_io;
 
 architecture rtl_one_wire_io of one_wire_io is
     
-  begin
-  
-    --DATA <= DOUT when DDIR='1' else "ZZZZZZZZ";
-    --DIN <= DATA;
+  begin 
     DQ <= 'Z' when DQ_CONTROL='1' else '0';
     
     process(MR, CLK)


### PR DESCRIPTION
Added wide inputs for simple access to the reading and writing. 
Added a restart counter as an example. 
Changed CLR behavior so it clears outputs and not just the error flag. 
added some simple cleanup of unused signals.